### PR TITLE
Fix duplicate items when using url anchors

### DIFF
--- a/js/repos.js
+++ b/js/repos.js
@@ -461,7 +461,10 @@
                     .attr("role", "tab").attr("data-toggle", "tab")
                     .append($("<i>").addClass("icon-Apps"))
                     .append($("<span>").text("All"))));
-                var teamAll = $("<div>").addClass("tab-pane active").attr("role", "tabpanel").attr("id", "All-" + group.name);
+                var teamAll = $("<div>").addClass("tab-pane").attr("role", "tabpanel").attr("id", "All-" + group.name);
+                if (initialTeam == "all") {
+                	teamAll.addClass("active");
+                }
                 for (var tname of group.teams) {
                   if (tname && MapTeams[tname]) {
                     var team = MapTeams[tname];


### PR DESCRIPTION
This pull request fixes an issue with items appearing twice when using anchors. The previous patch, #1, was missing a check on `initialTeam` to apply the `active` class for the default team's `div`.